### PR TITLE
Add new sort by price-rating and sort by date

### DIFF
--- a/imports/ui/FreshStrings.js
+++ b/imports/ui/FreshStrings.js
@@ -1,0 +1,3 @@
+export const PER_HUNDRED_GRAMS = "per 100g";
+export const PER_POUND = "per lb";
+export const PER_KILOGRAM = "per kg";

--- a/imports/ui/actions/AppActions.js
+++ b/imports/ui/actions/AppActions.js
@@ -35,6 +35,12 @@ export const getItems = filter => {
   };
 };
 
+export const sortItems = items => {
+  return dispatch => {
+    dispatch(fetchItemsSuccess(items));
+  };
+};
+
 export const changeRating = item => {
   return async dispatch => {
     return Meteor.call("updateItemRating", item, (err, res) => {

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -79,7 +79,7 @@ class CardComponent extends Component {
                   {this.state.data.name}
                 </Typography>
                 <Typography variant="subtitle1" color="textSecondary">
-                  {this.state.data.price}
+                  ${this.state.data.price}
                 </Typography>
                 <Typography variant="subtitle1" color="textSecondary">
                   {this.state.data.location.address}
@@ -94,14 +94,13 @@ class CardComponent extends Component {
 }
 const useStyles = theme => ({
   card: {
-    display: "flex",
+    display: "flex"
   },
   details: {
     width: "120px",
     height: "150px"
   },
-  insideDetails: {
-  },
+  insideDetails: {},
   content: {
     flex: "1 0 auto"
   },

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -79,7 +79,7 @@ class CardComponent extends Component {
                   {this.state.data.name}
                 </Typography>
                 <Typography variant="subtitle1" color="textSecondary">
-                  ${this.state.data.price}
+                  ${this.state.data.price} {this.state.data.unit}
                 </Typography>
                 <Typography variant="subtitle1" color="textSecondary">
                   {this.state.data.location.address}

--- a/imports/ui/components/CardList.jsx
+++ b/imports/ui/components/CardList.jsx
@@ -14,15 +14,29 @@ class CardList extends Component {
   }
 
   sortByPricePressed = () => {
-    var items = this.props.items.items;
+    let items = this.props.items.items;
 
     if (items.length > 1) {
       items.sort(function(a, b) {
+        // Function must be inside here or else cannot be used because of scope
+        let convertToKg = unitString => {
+          if (unitString == "per 100g") {
+            return 0.1;
+          } else if (unitString == "per lb") {
+            return 0.4536;
+          } else {
+            return 1;
+          }
+        };
+
+        let aPriceInKg = a.price * convertToKg(a.unit);
+        let bPriceInKg = b.price * convertToKg(b.unit);
+        console.log(aPriceInKg.toFixed(2), bPriceInKg.toFixed(2));
         // If price is the same, sort by rating
-        if (a.price === b.price) {
-          return a.rating - b.rating;
+        if (aPriceInKg.toFixed(2) === bPriceInKg.toFixed(2)) {
+          return b.rating - a.rating;
         } else {
-          return a.price - b.price;
+          return aPriceInKg - bPriceInKg;
         }
       });
 

--- a/imports/ui/components/CardList.jsx
+++ b/imports/ui/components/CardList.jsx
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import Card from "./Card";
 import SearchBar from "./SearchBar";
 import { getItems, sortItems } from "../actions/AppActions.js";
+import { PER_HUNDRED_GRAMS, PER_POUND, PER_KILOGRAM } from "../FreshStrings.js";
 
 class CardList extends Component {
   constructor() {
@@ -20,18 +21,20 @@ class CardList extends Component {
       items.sort(function(a, b) {
         // Function must be inside here or else cannot be used because of scope
         let convertToKg = unitString => {
-          if (unitString == "per 100g") {
-            return 0.1;
-          } else if (unitString == "per lb") {
-            return 0.4536;
-          } else {
-            return 1;
+          switch (unitString) {
+            case PER_HUNDRED_GRAMS:
+              return 0.1;
+            case PER_POUND:
+              0.4536;
+            case PER_KILOGRAM:
+              return 1;
+            default:
+              return null;
           }
         };
 
         let aPriceInKg = a.price * convertToKg(a.unit);
         let bPriceInKg = b.price * convertToKg(b.unit);
-        console.log(aPriceInKg.toFixed(2), bPriceInKg.toFixed(2));
         // If price is the same, sort by rating
         if (aPriceInKg.toFixed(2) === bPriceInKg.toFixed(2)) {
           return b.rating - a.rating;

--- a/imports/ui/components/CardList.jsx
+++ b/imports/ui/components/CardList.jsx
@@ -18,21 +18,11 @@ class CardList extends Component {
 
     if (items.length > 1) {
       items.sort(function(a, b) {
-        // TODO: Refactor after card with $h is remove from database
-        let aValue =
-          a.price.substr(1) && parseFloat(a.price.substr(1))
-            ? parseFloat(a.price.substr(1))
-            : 0;
-        let bValue =
-          b.price.substr(1) && parseFloat(b.price.substr(1))
-            ? parseFloat(b.price.substr(1))
-            : 0;
-
         // If price is the same, sort by rating
-        if (aValue === bValue) {
+        if (a.price === b.price) {
           return a.rating - b.rating;
         } else {
-          return aValue - bValue;
+          return a.price - b.price;
         }
       });
 

--- a/imports/ui/components/CardList.jsx
+++ b/imports/ui/components/CardList.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import Card from "./Card";
 import SearchBar from "./SearchBar";
-import { getItems } from "../actions/AppActions.js";
+import { getItems, sortItems } from "../actions/AppActions.js";
 
 class CardList extends Component {
   constructor() {
@@ -12,6 +12,48 @@ class CardList extends Component {
   componentDidMount() {
     this.props.getItems({});
   }
+
+  sortByPricePressed = () => {
+    var items = this.props.items.items;
+
+    if (items.length > 1) {
+      items.sort(function(a, b) {
+        // TODO: Refactor after card with $h is remove from database
+        let aValue =
+          a.price.substr(1) && parseFloat(a.price.substr(1))
+            ? parseFloat(a.price.substr(1))
+            : 0;
+        let bValue =
+          b.price.substr(1) && parseFloat(b.price.substr(1))
+            ? parseFloat(b.price.substr(1))
+            : 0;
+
+        // If price is the same, sort by rating
+        if (aValue === bValue) {
+          return a.rating - b.rating;
+        } else {
+          return aValue - bValue;
+        }
+      });
+
+      this.props.sortItems(items);
+    }
+  };
+
+  sortByLatestPressed = () => {
+    var items = this.props.items.items;
+
+    if (items.length > 1) {
+      items.sort(function(a, b) {
+        let aDate = new Date(a.createdAt);
+        let bDate = new Date(b.createdAt);
+
+        return bDate - aDate;
+      });
+    }
+
+    this.props.sortItems(items);
+  };
 
   render() {
     const items = this.props.items.items;
@@ -24,7 +66,9 @@ class CardList extends Component {
           placeholder="Find Item"
           onChange={true}
         />
-        {/* TODO: add filter */}
+        {/* Sort by price and rating */}
+        <p onClick={this.sortByPricePressed}>Sort by price</p>
+        <p onClick={this.sortByLatestPressed}>Sort by latest</p>
         {items.map(post => {
           return <Card key={post._id} post={post} />;
         })}
@@ -39,5 +83,5 @@ const mapStateToProps = state => {
 
 export default connect(
   mapStateToProps,
-  { getItems }
+  { getItems, sortItems }
 )(CardList);

--- a/imports/ui/components/FreshForm.jsx
+++ b/imports/ui/components/FreshForm.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
+import { Form, Radio } from "semantic-ui-react";
 import SearchBar from "./SearchBar";
 import GeoSuggest from "./GeoSuggest";
 import { connect } from "react-redux";
@@ -13,6 +14,7 @@ class FreshForm extends Component {
     this.state = {
       name: "",
       price: "",
+      unit: "",
       add: "",
       lat: 0,
       lng: 0
@@ -30,6 +32,10 @@ class FreshForm extends Component {
     this.setState({ price: event.target.value });
   };
 
+  handleChangeUnit = (event, { value }) => {
+    this.setState({ unit: value });
+  };
+
   setAddress = address => {
     this.setState({ add: address });
   };
@@ -41,6 +47,7 @@ class FreshForm extends Component {
     let newItem = {
       name: this.state.name,
       price: parseFloat(this.state.price),
+      unit: this.state.unit,
       createdAt: new Date(),
       rating: 0,
       location: {
@@ -64,6 +71,7 @@ class FreshForm extends Component {
           Submit a new deal!
         </Typography>
         <form onSubmit={this.handleSubmit}>
+          {/* Item Selection */}
           <SearchBar
             allowAddOptions={true}
             placeholder="Choose Item"
@@ -71,6 +79,8 @@ class FreshForm extends Component {
             onChange={false}
           />
           <br />
+
+          {/* Price Input */}
           <TextField
             label="Price"
             onChange={this.handleChangePrice}
@@ -82,7 +92,38 @@ class FreshForm extends Component {
             inputProps={{ min: "0", step: "0.01" }}
             required
           />
+
+          {/* Select Unit Choices */}
+          <Form.Field>
+            <Radio
+              label="per kg"
+              name="radioGroup"
+              value="per kg"
+              checked={this.state.unit === "per kg"}
+              onChange={this.handleChangeUnit}
+            />
+          </Form.Field>
+          <Form.Field>
+            <Radio
+              label="per lb"
+              name="radioGroup"
+              value="per lb"
+              checked={this.state.unit === "per lb"}
+              onChange={this.handleChangeUnit}
+            />
+          </Form.Field>
+          <Form.Field>
+            <Radio
+              label="per 100g"
+              name="radioGroup"
+              value="per 100g"
+              checked={this.state.unit === "per 100g"}
+              onChange={this.handleChangeUnit}
+            />
+          </Form.Field>
           <br />
+
+          {/* Location Input */}
           <GeoSuggest
             setAddress={this.setAddress.bind(this)}
             setLatLng={this.setLatLng.bind(this)}

--- a/imports/ui/components/FreshForm.jsx
+++ b/imports/ui/components/FreshForm.jsx
@@ -40,7 +40,7 @@ class FreshForm extends Component {
   handleSubmit = event => {
     let newItem = {
       name: this.state.name,
-      price: this.state.price,
+      price: parseFloat(this.state.price),
       createdAt: new Date(),
       rating: 0,
       location: {
@@ -79,7 +79,7 @@ class FreshForm extends Component {
             margin="normal"
             variant="outlined"
             type="number"
-            inputProps={{ min: "0", step: "any" }}
+            inputProps={{ min: "0", step: "0.01" }}
             required
           />
           <br />

--- a/imports/ui/components/FreshForm.jsx
+++ b/imports/ui/components/FreshForm.jsx
@@ -40,7 +40,7 @@ class FreshForm extends Component {
   handleSubmit = event => {
     let newItem = {
       name: this.state.name,
-      price: "$" + this.state.price,
+      price: this.state.price,
       createdAt: new Date(),
       rating: 0,
       location: {
@@ -78,6 +78,8 @@ class FreshForm extends Component {
             value={this.state.price}
             margin="normal"
             variant="outlined"
+            type="number"
+            inputProps={{ min: "0", step: "any" }}
             required
           />
           <br />

--- a/imports/ui/components/FreshForm.jsx
+++ b/imports/ui/components/FreshForm.jsx
@@ -7,6 +7,7 @@ import SearchBar from "./SearchBar";
 import GeoSuggest from "./GeoSuggest";
 import { connect } from "react-redux";
 import { addItem } from "../actions/AppActions.js";
+import { PER_HUNDRED_GRAMS, PER_POUND, PER_KILOGRAM } from "../FreshStrings.js";
 
 class FreshForm extends Component {
   constructor() {
@@ -96,28 +97,28 @@ class FreshForm extends Component {
           {/* Select Unit Choices */}
           <Form.Field>
             <Radio
-              label="per kg"
+              label={PER_KILOGRAM}
               name="radioGroup"
-              value="per kg"
-              checked={this.state.unit === "per kg"}
+              value={PER_KILOGRAM}
+              checked={this.state.unit === PER_KILOGRAM}
               onChange={this.handleChangeUnit}
             />
           </Form.Field>
           <Form.Field>
             <Radio
-              label="per lb"
+              label={PER_POUND}
               name="radioGroup"
-              value="per lb"
-              checked={this.state.unit === "per lb"}
+              value={PER_POUND}
+              checked={this.state.unit === PER_POUND}
               onChange={this.handleChangeUnit}
             />
           </Form.Field>
           <Form.Field>
             <Radio
-              label="per 100g"
+              label={PER_HUNDRED_GRAMS}
               name="radioGroup"
-              value="per 100g"
-              checked={this.state.unit === "per 100g"}
+              value={PER_HUNDRED_GRAMS}
+              checked={this.state.unit === PER_HUNDRED_GRAMS}
               onChange={this.handleChangeUnit}
             />
           </Form.Field>

--- a/server/main.js
+++ b/server/main.js
@@ -8,7 +8,8 @@ Meteor.startup(() => {
     let items = [
       {
         name: "Bananas",
-        price: "$0.99",
+        price: 0.99,
+        unit: "per lb",
         rating: 0,
         createdAt: new Date(),
         location: {
@@ -20,7 +21,8 @@ Meteor.startup(() => {
       },
       {
         name: "Apples",
-        price: "$1.99",
+        price: 1.99,
+        unit: "per kg",
         rating: 0,
         createdAt: new Date(),
         location: {
@@ -32,7 +34,8 @@ Meteor.startup(() => {
       },
       {
         name: "Pears",
-        price: "$2.99",
+        price: 2.99,
+        unit: "per lb",
         rating: 0,
         createdAt: new Date(),
         location: {
@@ -44,8 +47,9 @@ Meteor.startup(() => {
       },
       {
         name: "Oranges",
-        price: "$1.50",
+        price: 1.5,
         rating: 0,
+        unit: "per lb",
         createdAt: new Date(),
         location: {
           coords: {


### PR DESCRIPTION
Sort by price will sort by price first and if prices are tied, then tiebreaker will be by rating.
Sort by latest will sort by latest time stamp and show the recent at the top.

Updates:
- change `${price}` string in data to be stored as a number
- submission price input only takes numbers greater than 0 and two decimal places
- added sorting with consideration of the unit selected

![image](https://user-images.githubusercontent.com/17561746/60475385-e4f06f80-9c2b-11e9-9db9-adef4c400917.png)
