### PR TITLE
Style sort p tags into buttons

### DIFF
--- a/imports/ui/App.css
+++ b/imports/ui/App.css
@@ -52,6 +52,7 @@
   #SortButtons {
     margin-top: 3%;
     margin-bottom: 3%;
+    text-align: right !important;
   }
 
   ::-webkit-scrollbar {

--- a/imports/ui/components/CardList.jsx
+++ b/imports/ui/components/CardList.jsx
@@ -1,12 +1,17 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import Card from "./Card";
+import SearchBar from "./SearchBar";
+import SortButtons from "./SortButtons.jsx";
 import { getItems, sortItems } from "../actions/AppActions.js";
 import { PER_HUNDRED_GRAMS, PER_POUND, PER_KILOGRAM } from "../FreshStrings.js";
 
 class CardList extends Component {
   constructor() {
     super();
+    this.state = {
+      toggleOnState: "LATEST"
+    };
   }
 
   componentDidMount() {
@@ -44,6 +49,9 @@ class CardList extends Component {
 
       this.props.sortItems(items);
     }
+
+    // UPDATE SORT BUTTON
+    this.setState({ toggleOnState: "PRICE" });
   };
 
   sortByLatestPressed = () => {
@@ -59,6 +67,9 @@ class CardList extends Component {
     }
 
     this.props.sortItems(items);
+
+    // UPDATE SORT BUTTON
+    this.setState({ toggleOnState: "LATEST" });
   };
 
   render() {
@@ -66,13 +77,13 @@ class CardList extends Component {
 
     return (
       <div>
-        {/* Styling for SortButton inside App.css */}
-        <div id="SortButtons">
-          {/* Sort by price and rating */}
-          <p onClick={this.sortByPricePressed}>Sort by price</p>
-          <p onClick={this.sortByLatestPressed}>Sort by latest</p>
+        <div>
+          <SortButtons
+            sortByLatestPressed={this.sortByLatestPressed}
+            sortByPricePressed={this.sortByPricePressed}
+            toggleOnState={this.state.toggleOnState}
+          />
         </div>
-        {/* Styling for CardList inside App.css */}
         <div id="CardList">
           {items.map(post => {
             return <Card key={post._id} post={post} />;

--- a/imports/ui/components/CardList.jsx
+++ b/imports/ui/components/CardList.jsx
@@ -77,7 +77,7 @@ class CardList extends Component {
 
     return (
       <div>
-        <div>
+        <div id="SortButtons">
           <SortButtons
             sortByLatestPressed={this.sortByLatestPressed}
             sortByPricePressed={this.sortByPricePressed}

--- a/imports/ui/components/SortButtons.jsx
+++ b/imports/ui/components/SortButtons.jsx
@@ -1,0 +1,47 @@
+import React, { Component } from "react";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import ButtonGroup from "@material-ui/core/ButtonGroup";
+
+class SortButtons extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div>
+        <Grid item>
+          <ButtonGroup
+            variant="contained"
+            size="small"
+            aria-label="Sort buttons"
+          >
+            <Button
+              style={{
+                color: "white",
+                backgroundColor:
+                  this.props.toggleOnState == "LATEST" ? "#00600f" : "#75a478"
+              }}
+              onClick={this.props.sortByLatestPressed}
+            >
+              Sort by Latest
+            </Button>
+            <Button
+              style={{
+                color: "white",
+                backgroundColor:
+                  this.props.toggleOnState == "PRICE" ? "#00600f" : "#75a478"
+              }}
+              onClick={this.props.sortByPricePressed}
+            >
+              Sort by price
+            </Button>
+          </ButtonGroup>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+export default SortButtons;


### PR DESCRIPTION
Turn sort strings into actual buttons. They will also change states when pressed.

Rebased PR #46 into this branch.  This PR must be pushed after that one.

<img width="1345" alt="Screen Shot 2019-07-04 at 8 06 10 PM" src="https://user-images.githubusercontent.com/17561746/60695618-3a7c8480-9e97-11e9-945c-4917708427a6.png">


Closes #40 