### PR TITLE
Reduce map clutter

### DIFF
--- a/imports/ui/components/MapContainer.jsx
+++ b/imports/ui/components/MapContainer.jsx
@@ -58,6 +58,10 @@ export class MapContainer extends React.Component {
           google={this.props.google}
           onClick={this.onMapClicked}
           zoom={10}
+          scaleControl={true}
+          mapTypeControl={false}
+          fullscreenControl={false}
+          streetViewControl={false}
           initialCenter={{
             lat: 49.220037,
             lng: -122.974283


### PR DESCRIPTION
Don't need the streetview, fullscreen, or map type controls for our use case. 

Adds a useful scale at the bottom.
<img width="644" alt="Screen Shot 2019-07-04 at 9 32 40 PM" src="https://user-images.githubusercontent.com/25490855/60698270-86352b00-9ea3-11e9-98d9-0cf14951f9ac.png">
