### PR TITLE
Address shrinking bug

### DIFF
--- a/imports/ui/App.css
+++ b/imports/ui/App.css
@@ -77,10 +77,11 @@
 .new-post-fab {
   position: sticky !important;
   bottom: 20px !important;
+  z-index: 10;
 }
 
 .z-index-hidden {
-  z-index: -1;
+  z-index: 0;
 }
 
 #login-buttons a,

--- a/imports/ui/App.css
+++ b/imports/ui/App.css
@@ -70,7 +70,6 @@
   float: left;
 }
 
-
 ::-webkit-scrollbar {
   display: none;
 }
@@ -78,6 +77,10 @@
 .new-post-fab {
   position: sticky !important;
   bottom: 20px !important;
+}
+
+.z-index-hidden {
+  z-index: -1;
 }
 
 #login-buttons a,

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -65,7 +65,13 @@ class App extends Component {
           <div className="card-list">
             <CardList currentUser={this.props.currentUser} />
           </div>
-          <div className="new-post-fab">
+          <div
+            className={
+              this.props.currentUser === null
+                ? "z-index-hidden"
+                : "new-post-fab"
+            }
+          >
             <FreshModal currentUser={this.props.currentUser} />
           </div>
         </div>

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -97,11 +97,11 @@ class CardComponent extends Component {
               </CardActions>
             ) : (
               // All Card Details Info
-              <div
-                className={classes.insideDetails}
-                onClick={this.toggleDetails}
-              >
-                <CardContent className={classes.content}>
+              <div className={classes.insideDetails}>
+                <CardContent
+                  className={classes.content}
+                  onClick={this.toggleDetails}
+                >
                   <Typography component="h5" variant="h5">
                     {this.state.data.name}
                   </Typography>
@@ -116,13 +116,14 @@ class CardComponent extends Component {
                     {this.state.data.location.address}
                   </Typography>
                 </CardContent>
+
+                <AddShoppingList
+                  currentUser={this.props.currentUser}
+                  item={this.state.data}
+                />
               </div>
             )}
           </div>
-          <AddShoppingList
-            currentUser={this.props.currentUser}
-            item={this.state.data}
-          />
         </Card>
       </div>
     );
@@ -156,7 +157,8 @@ const useStyles = theme => ({
     flexGrow: 1
   },
   insideDetails: {
-    maxHeight: "113px"
+    maxHeight: "113px",
+    position: "relative"
   },
   content: {
     flex: "1 0 auto"

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -116,11 +116,12 @@ class CardComponent extends Component {
                     {this.state.data.location.address}
                   </Typography>
                 </CardContent>
-
-                <AddShoppingList
-                  currentUser={this.props.currentUser}
-                  item={this.state.data}
-                />
+                {this.props.currentUser && (
+                  <AddShoppingList
+                    currentUser={this.props.currentUser}
+                    item={this.state.data}
+                  />
+                )}
               </div>
             )}
           </div>

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -119,7 +119,10 @@ class CardComponent extends Component {
               </div>
             )}
           </div>
-          {this.props.currentUser && <AddShoppingList item={this.state.data} />}
+          <AddShoppingList
+            currentUser={this.props.currentUser}
+            item={this.state.data}
+          />
         </Card>
       </div>
     );

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -141,7 +141,6 @@ const useStyles = theme => ({
     }
   },
   details: {
-    display: "flex",
     flexDirection: "column",
     justifyContent: "center",
     flexGrow: 1

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -141,6 +141,7 @@ const useStyles = theme => ({
     }
   },
   details: {
+    display: "flex",
     flexDirection: "column",
     justifyContent: "center",
     flexGrow: 1

--- a/imports/ui/components/Modal.jsx
+++ b/imports/ui/components/Modal.jsx
@@ -39,17 +39,15 @@ class Modal extends Component {
 
     return (
       <div>
-        {this.props.currentUser && (
-          <Fab
-            color="secondary"
-            aria-label="Edit"
-            className="NewPostFab"
-            onClick={this.handleOpen}
-            variant="extended"
-          >
-            <AddIcon /> Fresh Deal
-          </Fab>
-        )}
+        <Fab
+          color="secondary"
+          aria-label="Edit"
+          className="NewPostFab"
+          onClick={this.handleOpen}
+          variant="extended"
+        >
+          <AddIcon /> Fresh Deal
+        </Fab>
 
         <MaterialModal
           aria-labelledby="modal-title"

--- a/imports/ui/components/SnackBar.jsx
+++ b/imports/ui/components/SnackBar.jsx
@@ -52,7 +52,6 @@ class CustomizedSnackbars extends Component {
         }
       >
         <IconButton
-          disable={true}
           style={{ display: this.state.isAdded ? "none" : "" }}
           onClick={this.onAdd}
         >

--- a/imports/ui/components/SnackBar.jsx
+++ b/imports/ui/components/SnackBar.jsx
@@ -46,8 +46,13 @@ class CustomizedSnackbars extends Component {
   };
   render() {
     return (
-      <div>
+      <div
+        className={
+          this.props.currentUser === null ? "z-index-hidden" : "add-cart-button"
+        }
+      >
         <IconButton
+          disable={true}
           style={{ display: this.state.isAdded ? "none" : "" }}
           onClick={this.onAdd}
         >

--- a/imports/ui/components/SnackBar.jsx
+++ b/imports/ui/components/SnackBar.jsx
@@ -50,7 +50,13 @@ class CustomizedSnackbars extends Component {
         className={
           this.props.currentUser === null ? "z-index-hidden" : "add-cart-button"
         }
-        style={{ position: "absolute", top: "0", right: "0", zIndex: "10" }}
+        style={{
+          position: "absolute",
+          top: "0",
+          right: "0",
+          zIndex: "5",
+          padding: "0"
+        }}
       >
         <IconButton
           style={{ display: this.state.isAdded ? "none" : "" }}

--- a/imports/ui/components/SnackBar.jsx
+++ b/imports/ui/components/SnackBar.jsx
@@ -50,6 +50,7 @@ class CustomizedSnackbars extends Component {
         className={
           this.props.currentUser === null ? "z-index-hidden" : "add-cart-button"
         }
+        style={{ position: "absolute", top: "0", right: "0", zIndex: "10" }}
       >
         <IconButton
           style={{ display: this.state.isAdded ? "none" : "" }}


### PR DESCRIPTION
This is going to be controversial...

Hidden components don't have a dimension. When you unhide the component, the dimensions get revealed and added to the page re-render. This causes some pretty noticeable page size changes. 

Because my css/frontend skills are trash, I don't know how to properly address it. So instead, I render the component behind the page with a negative z-index... and when the user logs in, remove the z-index styling. This gives the appearance of "un-hiding" the buttons when they're in reality already there... just not clickable. 

Anyway, if you guys know of a better way to address this issue, I'm all ears! 