### PR TITLE
Add posted date details to card back, tooltips

### DIFF
--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -90,8 +90,11 @@ class CardComponent extends Component {
                 className={classes.addressOnly}
               >
                 <CardContent>
-                  <Typography variant="subtitle1" color="textSecondary">
+                  <Typography variant="subtitle2" color="textSecondary">
                     {this.state.data.location.address}
+                  </Typography>
+                  <Typography variant="caption" color="textSecondary">
+                    Posted on {this.state.data.createdAt.toLocaleString()}
                   </Typography>
                 </CardContent>
               </CardActions>

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -5,6 +5,7 @@ import CardContent from "@material-ui/core/CardContent";
 import CardActions from "@material-ui/core/CardActions";
 import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
+import Tooltip from "@material-ui/core/Tooltip";
 import ThumbDownOutlinedIcon from "@material-ui/icons/ThumbDownOutlined";
 import ThumbUpOutlinedIcon from "@material-ui/icons/ThumbUpOutlined";
 import { connect } from "react-redux";
@@ -84,7 +85,7 @@ class CardComponent extends Component {
           {/* Food Details */}
           <div className={classes.details}>
             {this.state.showDetails && this.state.data.location.address ? (
-              // Address Only Side
+              // Address and Posted Date Side
               <CardActions
                 onClick={this.toggleDetails}
                 className={classes.addressOnly}
@@ -111,13 +112,18 @@ class CardComponent extends Component {
                   <Typography variant="subtitle1" color="textSecondary">
                     ${this.state.data.price} {this.state.data.unit}
                   </Typography>
-                  <Typography
-                    variant="subtitle2"
-                    className={classes.longAddress}
-                    color="textSecondary"
+                  <Tooltip
+                    enterDelay={500}
+                    title="Click for additional details"
                   >
-                    {this.state.data.location.address}
-                  </Typography>
+                    <Typography
+                      variant="subtitle2"
+                      className={classes.longAddress}
+                      color="textSecondary"
+                    >
+                      {this.state.data.location.address}
+                    </Typography>
+                  </Tooltip>
                 </CardContent>
               </div>
             )}

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -106,23 +106,25 @@ class CardComponent extends Component {
                 onClick={this.toggleDetails}
               >
                 <CardContent className={classes.content}>
-                  <Typography component="h5" variant="h5">
-                    {this.state.data.name}
-                  </Typography>
-                  <Typography variant="subtitle1" color="textSecondary">
-                    ${this.state.data.price} {this.state.data.unit}
-                  </Typography>
                   <Tooltip
                     enterDelay={500}
                     title="Click for additional details"
                   >
-                    <Typography
-                      variant="subtitle2"
-                      className={classes.longAddress}
-                      color="textSecondary"
-                    >
-                      {this.state.data.location.address}
-                    </Typography>
+                    <div>
+                      <Typography component="h5" variant="h5">
+                        {this.state.data.name}
+                      </Typography>
+                      <Typography variant="subtitle1" color="textSecondary">
+                        ${this.state.data.price} {this.state.data.unit}
+                      </Typography>
+                      <Typography
+                        variant="subtitle2"
+                        className={classes.longAddress}
+                        color="textSecondary"
+                      >
+                        {this.state.data.location.address}
+                      </Typography>
+                    </div>
                   </Tooltip>
                 </CardContent>
               </div>

--- a/imports/ui/components/SnackBar.jsx
+++ b/imports/ui/components/SnackBar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import IconButton from "@material-ui/core/IconButton";
 import Snackbar from "@material-ui/core/Snackbar";
+import Tooltip from "@material-ui/core/Tooltip";
 import AddIcon from "@material-ui/icons/PlaylistAdd";
 import CheckedIcon from "@material-ui/icons/PlaylistAddCheck";
 import MySnackbarContentWrapper from "./SnackBarContentWrapper.jsx";
@@ -47,12 +48,14 @@ class CustomizedSnackbars extends Component {
   render() {
     return (
       <div>
-        <IconButton
-          style={{ display: this.state.isAdded ? "none" : "" }}
-          onClick={this.onAdd}
-        >
-          <AddIcon />
-        </IconButton>
+        <Tooltip enterDelay={500} placement="left" title="Add to Shopping Cart">
+          <IconButton
+            style={{ display: this.state.isAdded ? "none" : "" }}
+            onClick={this.onAdd}
+          >
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
         <IconButton
           style={{ display: this.state.isAdded ? "" : "none" }}
           onClick={this.onAdd}


### PR DESCRIPTION
Add posted date to the back of the cards. 
![image](https://user-images.githubusercontent.com/25490855/61997115-c70f0280-b051-11e9-81b8-7d00d186b49c.png)


Add a hover tooltip to the add to shopping cart icon
![image](https://user-images.githubusercontent.com/25490855/61997117-cc6c4d00-b051-11e9-86a9-dccd8ae82813.png)


Add a hover tooltip to the truncated address. 
![image](https://user-images.githubusercontent.com/25490855/61997119-d2fac480-b051-11e9-848b-90540f7d444b.png)

