### PR TITLE
Add state to thumbs up and down rating

### DIFF
--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -7,6 +7,8 @@ import IconButton from "@material-ui/core/IconButton";
 import Typography from "@material-ui/core/Typography";
 import ThumbDownOutlinedIcon from "@material-ui/icons/ThumbDownOutlined";
 import ThumbUpOutlinedIcon from "@material-ui/icons/ThumbUpOutlined";
+import ThumbDownSolidIcon from "@material-ui/icons/ThumbDown";
+import ThumbUpSolidIcon from "@material-ui/icons/ThumbUp";
 import { connect } from "react-redux";
 import { changeRating } from "../actions/AppActions.js";
 import AddShoppingList from "./SnackBar";
@@ -20,20 +22,46 @@ class CardComponent extends Component {
       data: this.props.post,
       imageSrc: this.props.post.imageSrc,
       showDetails: false,
-      isLightboxOpen: false
+      isLightboxOpen: false,
+      thumbsUpIcon: "outline",
+      thumbsDownIcon: "outline"
     };
   }
 
-  onThumbsUpPressed = () => {
+  onThumbsUpOutlinedPressed = () => {
     let item = this.state.data;
     item.rating = item.rating + 1;
     this.props.changeRating(item);
+    if (this.state.thumbsDownIcon == "solid") {
+      this.setState({ thumbsDownIcon: "outline" });
+    } else {
+      this.setState({ thumbsUpIcon: "solid" });
+    }
   };
 
-  onThumbsDownPressed = () => {
+  onThumbsDownOutlinedPressed = () => {
     let item = this.state.data;
     item.rating = item.rating - 1;
     this.props.changeRating(item);
+    if (this.state.thumbsUpIcon == "solid") {
+      this.setState({ thumbsUpIcon: "outline" });
+    } else {
+      this.setState({ thumbsDownIcon: "solid" });
+    }
+  };
+
+  onThumbsUpSolidPressed = () => {
+    let item = this.state.data;
+    item.rating = item.rating - 1;
+    this.props.changeRating(item);
+    this.setState({ thumbsUpIcon: "outline" });
+  };
+
+  onThumbsDownSolidPressed = () => {
+    let item = this.state.data;
+    item.rating = item.rating + 1;
+    this.props.changeRating(item);
+    this.setState({ thumbsDownIcon: "outline" });
   };
 
   imageNotFoundError = () => {
@@ -57,15 +85,33 @@ class CardComponent extends Component {
         <Card className={classes.card}>
           {/* Thumbs Up and Down Counter */}
           <div className={classes.ratingArea}>
-            <div className={classes.thumbs}>
-              <IconButton onClick={this.onThumbsUpPressed}>
-                <ThumbUpOutlinedIcon />
-              </IconButton>
-              <div className={classes.rating}>{this.state.data.rating}</div>
-              <IconButton onClick={this.onThumbsDownPressed}>
-                <ThumbDownOutlinedIcon />
-              </IconButton>
-            </div>
+            {this.state.thumbsUpIcon == "outline" ? (
+              <div className={classes.thumbs}>
+                <IconButton onClick={this.onThumbsUpOutlinedPressed}>
+                  <ThumbUpOutlinedIcon />
+                </IconButton>
+              </div>
+            ) : (
+              <div className={classes.thumbs}>
+                <IconButton onClick={this.onThumbsUpSolidPressed}>
+                  <ThumbUpSolidIcon />
+                </IconButton>
+              </div>
+            )}
+            <div className={classes.rating}>{this.state.data.rating}</div>
+            {this.state.thumbsDownIcon == "outline" ? (
+              <div className={classes.thumbs}>
+                <IconButton onClick={this.onThumbsDownOutlinedPressed}>
+                  <ThumbDownOutlinedIcon />
+                </IconButton>
+              </div>
+            ) : (
+              <div className={classes.thumbs}>
+                <IconButton onClick={this.onThumbsDownSolidPressed}>
+                  <ThumbDownSolidIcon />
+                </IconButton>
+              </div>
+            )}
           </div>
           {/* Food Image */}
           <img


### PR DESCRIPTION
This PR is to add restrictions to hitting thumbs up/down many many times. Note, public user refreshing page can add another rating. 

- Add logic to turn outline to solid thumb
- Add logic to undo a solid from opposite thumb
- Add logic to undo a solid from the same thumb

![Jul-27-2019 23-50-45](https://user-images.githubusercontent.com/17561746/62003276-7fc45880-b0c9-11e9-9a28-6de9be5dfd8a.gif)


