### PR TITLE
Fix add to shopping bug, widescreen styling

### DIFF
--- a/imports/ui/App.css
+++ b/imports/ui/App.css
@@ -8,7 +8,7 @@
 .AppContainer {
   display: grid;
   grid-template-areas: "left-section left-section right-section";
-  grid-template-columns: 1fr 1fr 1.5fr;
+  grid-template-columns: auto auto 625px;
   height: 100vh;
   width: 100vw;
   overflow: hidden;

--- a/imports/ui/components/Card.jsx
+++ b/imports/ui/components/Card.jsx
@@ -147,11 +147,11 @@ class CardComponent extends Component {
               </CardActions>
             ) : (
               // All Card Details Info
-              <div
-                className={classes.insideDetails}
-                onClick={this.toggleDetails}
-              >
-                <CardContent className={classes.content}>
+              <div className={classes.insideDetails}>
+                <CardContent
+                  className={classes.content}
+                  onClick={this.toggleDetails}
+                >
                   <Tooltip
                     enterDelay={500}
                     title="Click for additional details"


### PR DESCRIPTION
The onclick in the wrong div was causing the bug --  clicking add to shopping cart flipped the card instead. 

Also adds some styling for widescreen monitors. 
On a mac (looks the same as before)
<img width="1440" alt="Screen Shot 2019-08-02 at 12 34 17 PM" src="https://user-images.githubusercontent.com/25490855/62394360-de526200-b521-11e9-8387-8e7d88c99305.png">





On widescreen, looks like this:
![image](https://user-images.githubusercontent.com/25490855/62394429-0f329700-b522-11e9-828a-70a964fe8fd2.png)





Before on widescreen, used to look like this:
![image](https://user-images.githubusercontent.com/25490855/62394463-240f2a80-b522-11e9-9fe0-afe292340ef9.png)
